### PR TITLE
Add reference to the original Killswitch project in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,6 +6,11 @@
   </p>
 </div>
 
+
+## What is Killswitch?
+
+[Killswitch is a clever control panel](https://github.com/mirego/killswitch) built by Mirego that allows mobile developers to apply runtime version-specific behaviors to their iOS or Android application.
+
 ## Installation
 
 ```sh


### PR DESCRIPTION
I think we should mention the original Killswitch project in the README to add more context as to why this library exists and how it can be used.