### PR TITLE
Make zod a dependency, not a dev dependency

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 lib
 coverage
+node_modules

--- a/package.json
+++ b/package.json
@@ -71,8 +71,7 @@
     "react-native-builder-bob": "^0.20.1",
     "react-test-renderer": "^18.2.0",
     "release-it": "^15.0.0",
-    "typescript": "^4.5.2",
-    "zod": "^3.21.4"
+    "typescript": "^4.5.2"
   },
   "peerDependencies": {
     "react": "*",
@@ -112,5 +111,8 @@
         }
       ]
     ]
+  },
+  "dependencies": {
+    "zod": "^3.21.4"
   }
 }


### PR DESCRIPTION
zod is used by the runtime code but was declared as a dev dependency, so it wasn't installed in project that required react-native-killswitch.