### PR TITLE
Fix CI workflow and badge

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -3,7 +3,7 @@ name: CI
 on:
   push:
     branches:
-      - master
+      - main
   pull_request:
     branches:
       - '**'

--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@
     <strong>React Native Killswitch</strong> is a library built by <a href="https://www.mirego.com">Mirego</a> that allows mobile developers to apply<br /> runtime version-specific behaviors to their React Native application.
   </p>
   
-  <a href="https://github.com/mirego/react-native-killswitch/actions/workflows/ci.yaml"><img src="https://github.com/mirego/react-native-killswitch/actions/workflows/ci.yaml/badge.svg" /></a>
+  <a href="https://github.com/mirego/react-native-killswitch/actions/workflows/ci.yaml"><img src="https://github.com/mirego/react-native-killswitch/actions/workflows/ci.yaml/badge.svg?branch=main" /></a>
   <a href="https://github.com/mirego/react-native-killswitch/tags"><img src="https://img.shields.io/npm/v/react-native-killswitch.svg"></a><br /><br />
 </div>
 


### PR DESCRIPTION
## 📖 Description

We were using a generic badge image which was referencing the latest CI workflow run across the project, not just the latest one that ran on the main branch.

Also, CI was configured to run for `master` pushes, not `main` 🤦‍♂️ 

## 🦀 Dispatch

- `#dispatch/devops`