### PR TITLE
Enabled

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,6 +33,7 @@ const { isOk } = useKillswitch({
   androidApiKey: androidApiKey,
   language: myAppLanguage,
   version: myAppVersion,
+  enabled: true,
 });
 ```
 
@@ -62,6 +63,9 @@ const { isOk } = useKillswitch({
 
 - `timeout`
   A number of milliseconds to wait for the back-end before returning `isOk = true`. Defaults to `2000`
+
+- `enabled`
+  Toggle if you want to disabled. Defaults to `true`
 
 ## License
 

--- a/src/__tests__/use-killswitch.test.tsx
+++ b/src/__tests__/use-killswitch.test.tsx
@@ -54,18 +54,6 @@ describe('useKillswitch()', () => {
     appStateSpy.mockRestore();
   });
 
-  it('should display "is ok" when enabled is false', async () => {
-    fetchMock.mockResponseOnce(JSON.stringify({ isOk: true }));
-
-    const { rerender, getByTestId } = render(<App />);
-
-    rerender(<App enabled={false} />);
-
-    await waitFor(() => {
-      expect(getByTestId('killswitch-text').props.children).toBe('is ok');
-    });
-  });
-
   describe('when it receives an "ok" signal', () => {
     beforeEach(() => {
       fetchMock.mockResponse((_request) => {
@@ -75,6 +63,16 @@ describe('useKillswitch()', () => {
 
     it('should return `isOk = true`', async () => {
       render(<App />);
+
+      await waitFor(() => screen.getByText('is ok'));
+    }, 8000);
+
+    it('should display "is ok" when enabled is false', async () => {
+      fetchMock.mockResponseOnce(JSON.stringify({ isOk: true }));
+
+      const { rerender } = render(<App />);
+
+      rerender(<App enabled={false} />);
 
       await waitFor(() => screen.getByText('is ok'));
     }, 8000);

--- a/src/__tests__/use-killswitch.test.tsx
+++ b/src/__tests__/use-killswitch.test.tsx
@@ -12,7 +12,7 @@ import { useKillswitch } from '../use-killswitch';
 import fetchMock from 'jest-fetch-mock';
 import spyOnAlert from '../__utils__/spy-on-alert';
 
-function App() {
+function App({ enabled = true }: { enabled?: boolean }) {
   const { isOk } = useKillswitch({
     iosApiKey: 'apiKey',
     androidApiKey: 'apiKey',
@@ -20,6 +20,7 @@ function App() {
     version: '1.0.0',
     apiHost: 'https://killswitch.mirego.com',
     timeout: 200,
+    enabled,
   });
 
   return (
@@ -51,6 +52,18 @@ describe('useKillswitch()', () => {
 
     appStateSpy.mockReset();
     appStateSpy.mockRestore();
+  });
+
+  it('should display "is ok" when enabled is false', async () => {
+    fetchMock.mockResponseOnce(JSON.stringify({ isOk: true }));
+
+    const { rerender, getByTestId } = render(<App />);
+
+    rerender(<App enabled={false} />);
+
+    await waitFor(() => {
+      expect(getByTestId('killswitch-text').props.children).toBe('is ok');
+    });
   });
 
   describe('when it receives an "ok" signal', () => {

--- a/src/killswitch.ts
+++ b/src/killswitch.ts
@@ -42,6 +42,7 @@ interface KillswitchOptions {
   androidApiKey: string;
   useNativeUI?: boolean;
   timeout?: number;
+  enabled?: boolean;
 }
 
 class Killswitch {
@@ -50,6 +51,7 @@ class Killswitch {
   androidApiKey: string;
   useNativeUI: boolean;
   timeout: number;
+  enabled: boolean;
 
   behavior?: z.infer<typeof KillswitchBehavior>;
 
@@ -59,12 +61,14 @@ class Killswitch {
     androidApiKey,
     useNativeUI = true,
     timeout = 2000,
+    enabled = true,
   }: KillswitchOptions) {
     this.apiHost = apiHost;
     this.iosApiKey = iosApiKey;
     this.androidApiKey = androidApiKey;
     this.useNativeUI = useNativeUI;
     this.timeout = timeout;
+    this.enabled = enabled;
   }
 
   get isOk() {
@@ -79,7 +83,8 @@ class Killswitch {
     return this.behavior?.action === KillswitchBehaviorAction.KILL;
   }
 
-  async check(language: string, version: string) {
+  async check(language: string, version: string, enabled: boolean) {
+    if (!enabled) return { isOk: true };
     try {
       const payload = await this.fetch(language, version);
 
@@ -120,7 +125,6 @@ class Killswitch {
           signal,
         }
       );
-
       return response.json();
     } finally {
       clearTimeout(timeout);
@@ -131,6 +135,10 @@ class Killswitch {
     if (!this.behavior) return;
 
     if (this.isOk) {
+      return;
+    }
+
+    if (!this.enabled) {
       return;
     }
 


### PR DESCRIPTION
## 📖 Description

Possibility to enable or disable the killswitch.

## ⚠️ Problem

When we want to force an update, if the app goes into the background and then returns to the foreground, it reopens the alert, and gradually, the background becomes increasingly darker.

## 🤓 Solution

I added a parameter enabled that allows the validation to be activated or deactivated. For example, if I set enabled to true on the first render and later set it to false, when I put the app in the background and then return to the foreground, there are no more multiple alerts.


## 🦀 Dispatch

- `#dispatch/react`
- `#dispatch/react-native`
